### PR TITLE
feat: add handling of 'LAError.Code.passcodeNotSet' error

### DIFF
--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationError.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationError.swift
@@ -28,10 +28,13 @@ import Foundation
 public enum LocalAuthenticationError: Error {
     // MARK: - Error codes for common local authentication errors.
     
-    /// -6
+    /// -5, LAError.Code.passcodeNotSet
+    public static let passcodeNotSet: Int = -5
+    
+    /// -6, LAError.Code.biometryNotAvailable
     public static let denied: Int = -6
     
-    /// -7
+    /// -7, LAError.Code.biometryNotEnrolled
     public static let noBiometricsEnrolled: Int = -7
     
     /// 0
@@ -51,6 +54,9 @@ public enum LocalAuthenticationError: Error {
     
     /// No fingerprints are enrolled on the device.
     case noFingerprintEnrolled
+    
+    /// A passcode isn’t set on the device.
+    case noPasscodeSet
     
     /// An underlying error occurred.
     ///

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
@@ -70,9 +70,12 @@ public final class LocalAuthenticationProvider: LocalAuthenticationProviderProto
                         logger.error("\(#function) Local Authentication Error: \(error.localizedDescription)")
                         throw LocalAuthenticationError.biometricError
                     }
+                case LocalAuthenticationError.passcodeNotSet:
+                    logger.error("\(#function) Check biometric auth available: \(error.localizedDescription)")
+                    throw LocalAuthenticationError.noPasscodeSet
                 default:
                     logger.error("\(#function) Local Authentication Error: \(error.localizedDescription)")
-                    throw LocalAuthenticationError.biometricError
+                    throw LocalAuthenticationError.error(error)
                 }
             }
             return false


### PR DESCRIPTION
# Title

## Motivation

Need to provide users ability to handle issues which might happen when device passcode is not set

## Modifications

 - Extend LocalAuthenticationError with new case 'noPasscodeSet'. 
 - Add handling of 'LAError.Code.passcodeNotSet' error by LocalAuthenticationProvider
 - Add tests covering introduced changes

## Result

Users have a way to handle 'passcodeNotSet' error 
