### PR TITLE
feat: allow set desired policy when checking biometric auth availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Use the provided methods to perform authentication tasks:
 
 ```swift
 // Check if biometric authentication is available
-if try await provider.checkBiometricAvailable() {
+if try await provider.checkBiometricAvailable(with: .biometrics) {
     // Set up biometric authentication
     if try await provider.setBiometricAuthentication(localizedReason: "Authenticate to access your data") {
         // Authenticate the user

--- a/Sources/LocalAuthenticationProvider/LAContext+Extensions.swift
+++ b/Sources/LocalAuthenticationProvider/LAContext+Extensions.swift
@@ -1,0 +1,27 @@
+//
+//  LAContext+Extensions.swift
+//
+//
+//  Created by Andriy Vasyk on 02.09.2024.
+//
+
+import Foundation
+import LocalAuthentication
+
+extension LAContext {
+    internal func canEvaluate(policy: LocalAuthenticationPolicy, error: NSErrorPointer) -> Bool {
+        let localPolicy: LAPolicy
+        switch policy {
+        case .authentication:
+            localPolicy = .deviceOwnerAuthentication
+        case .watch:
+            localPolicy = .deviceOwnerAuthenticationWithWatch
+        case .biometrics:
+            localPolicy = .deviceOwnerAuthenticationWithBiometrics
+        case .biometricsOrWatch:
+            localPolicy = .deviceOwnerAuthenticationWithBiometricsOrWatch
+        }
+
+        return self.canEvaluatePolicy(localPolicy, error: error)
+    }
+}

--- a/Sources/LocalAuthenticationProvider/LAContext+Extensions.swift
+++ b/Sources/LocalAuthenticationProvider/LAContext+Extensions.swift
@@ -14,12 +14,14 @@ extension LAContext {
         switch policy {
         case .authentication:
             localPolicy = .deviceOwnerAuthentication
-        case .watch:
-            localPolicy = .deviceOwnerAuthenticationWithWatch
         case .biometrics:
             localPolicy = .deviceOwnerAuthenticationWithBiometrics
+#if os(macOS)
+        case .watch:
+            localPolicy = .deviceOwnerAuthenticationWithWatch
         case .biometricsOrWatch:
             localPolicy = .deviceOwnerAuthenticationWithBiometricsOrWatch
+#endif
         }
 
         return self.canEvaluatePolicy(localPolicy, error: error)

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationPolicy.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationPolicy.swift
@@ -14,9 +14,11 @@ public enum LocalAuthenticationPolicy: Int {
     /// Device owner will be authenticated by biometry or user password.
     case authentication = 2
 
+#if os(macOS)
     /// Device owner will be authenticated by Apple Watch.
     case watch = 3
 
     /// Device owner will be authenticated by biometry or Apple Watch.
     case biometricsOrWatch = 4
+#endif
 }

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationPolicy.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationPolicy.swift
@@ -1,0 +1,22 @@
+//
+//  LocalAuthenticationPolicy.swift
+//
+//
+//  Created by Andriy Vasyk on 02.09.2024.
+//
+
+import Foundation
+
+public enum LocalAuthenticationPolicy: Int {
+    /// Device owner will be authenticated using a biometric method (Touch ID).
+    case biometrics = 1
+
+    /// Device owner will be authenticated by biometry or user password.
+    case authentication = 2
+
+    /// Device owner will be authenticated by Apple Watch.
+    case watch = 3
+
+    /// Device owner will be authenticated by biometry or Apple Watch.
+    case biometricsOrWatch = 4
+}

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
@@ -49,20 +49,8 @@ public final class LocalAuthenticationProvider: LocalAuthenticationProviderProto
     /// - Returns: `true` if biometric authentication is available, `false` otherwise.
     /// - Throws: An appropriate `LocalAuthenticationError` if an error occurs during the check.
     public func checkBiometricAvailable(with policy: LocalAuthenticationPolicy) async throws -> Bool {
-        let localPolicy: LAPolicy
-        switch policy {
-        case .authentication:
-            localPolicy = .deviceOwnerAuthentication
-        case .watch:
-            localPolicy = .deviceOwnerAuthenticationWithWatch
-        case .biometrics:
-            localPolicy = .deviceOwnerAuthenticationWithBiometrics
-        case .biometricsOrWatch:
-            localPolicy = .deviceOwnerAuthenticationWithBiometricsOrWatch
-        }
-        
         var error: NSError?
-        if context.canEvaluatePolicy(localPolicy, error: &error) {
+        if context.canEvaluate(policy: policy, error: &error) {
             return true
         } else {
             if let error {

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationProviderProtocol.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationProviderProtocol.swift
@@ -28,9 +28,10 @@ import Foundation
 public protocol LocalAuthenticationProviderProtocol {
     /// Checks if biometric authentication is available on the device.
     ///
+    /// - Parameter policy: The policy to evaluate.
     /// - Returns: `true` if biometric authentication is available, `false` otherwise.
     /// - Throws: An appropriate `LocalAuthenticationError` if an error occurs during the check.
-    func checkBiometricAvailable() async throws -> Bool
+    func checkBiometricAvailable(with policy: LocalAuthenticationPolicy) async throws -> Bool
     
     /// Sets up biometric authentication with the given localized reason, preparing for authentication but not initiating it immediately.
     ///

--- a/Tests/LocalAuthenticationProviderTests/LocalAuthenticationProviderTests.swift
+++ b/Tests/LocalAuthenticationProviderTests/LocalAuthenticationProviderTests.swift
@@ -29,19 +29,19 @@ final class LocalAuthenticationProviderTests: XCTestCase {
     func testCanEvaluatePolicyWhenOwnerAuthenticatedWithBiometrics() async throws {
         let context = MockLAContext(canEvaluatePolicies: [.deviceOwnerAuthenticationWithBiometrics])
         let provider = LocalAuthenticationProvider(context: context)
-        let checkBiometricsSuccess = try await provider.checkBiometricAvailable()
+        let checkBiometricsSuccess = try await provider.checkBiometricAvailable(with: .biometrics)
         XCTAssert(checkBiometricsSuccess)
     }
     
     func testCanEvaluatePolicyWhenOwnerNotAuthenticateWithBiometricsIssue() async throws {
-        let result = try await provider.checkBiometricAvailable()
+        let result = try await provider.checkBiometricAvailable(with: .biometrics)
         XCTAssertFalse(result)
     }
     
     func testCanEvaluatePolicyWhenOwnerAlreadyAuthenticated() async throws {
         let context = MockLAContext(canEvaluatePolicies: [.deviceOwnerAuthentication])
         let provider = LocalAuthenticationProvider(context: context)
-        let checkBiometricsSuccess = try await provider.checkBiometricAvailable()
+        let checkBiometricsSuccess = try await provider.checkBiometricAvailable(with: .authentication)
         XCTAssert(checkBiometricsSuccess)
     }
     
@@ -50,7 +50,7 @@ final class LocalAuthenticationProviderTests: XCTestCase {
         let context = MockLAContext(canEvaluatePolicyError: NSError(domain: "", code: errorCode))
         let provider = LocalAuthenticationProvider(context: context)
         do {
-            _ = try await provider.checkBiometricAvailable()
+            _ = try await provider.checkBiometricAvailable(with: .biometrics)
             XCTFail("Error must be thrown")
         } catch LocalAuthenticationError.deniedAccess {
         } catch {
@@ -63,7 +63,7 @@ final class LocalAuthenticationProviderTests: XCTestCase {
         let context = MockLAContext(canEvaluatePolicyError: NSError(domain: "", code: errorCode))
         let provider = LocalAuthenticationProvider(context: context)
         do {
-            _ = try await provider.checkBiometricAvailable()
+            _ = try await provider.checkBiometricAvailable(with: .biometrics)
             XCTFail(".noPasscodeSet error must be thrown")
         } catch LocalAuthenticationError.noPasscodeSet {
         } catch {
@@ -76,7 +76,7 @@ final class LocalAuthenticationProviderTests: XCTestCase {
         let context = MockLAContext(canEvaluatePolicyError: NSError(domain: "", code: errorCode))
         let provider = LocalAuthenticationProvider(context: context)
         do {
-            _ = try await provider.checkBiometricAvailable()
+            _ = try await provider.checkBiometricAvailable(with: .biometrics)
             XCTFail("Error must be thrown")
         } catch LocalAuthenticationError.biometricError {
         } catch {
@@ -89,7 +89,7 @@ final class LocalAuthenticationProviderTests: XCTestCase {
         let context = MockLAContext(canEvaluatePolicyError: NSError(domain: "", code: errorCode), biometryType: .faceID)
         let provider = LocalAuthenticationProvider(context: context)
         do {
-            _ = try await provider.checkBiometricAvailable()
+            _ = try await provider.checkBiometricAvailable(with: .biometrics)
             XCTFail("Error must be thrown")
         } catch LocalAuthenticationError.noFaceIdEnrolled {
         } catch {
@@ -102,7 +102,7 @@ final class LocalAuthenticationProviderTests: XCTestCase {
         let context = MockLAContext(canEvaluatePolicyError: NSError(domain: "", code: errorCode), biometryType: .touchID)
         let provider = LocalAuthenticationProvider(context: context)
         do {
-            _ = try await provider.checkBiometricAvailable()
+            _ = try await provider.checkBiometricAvailable(with: .biometrics)
             XCTFail("Error must be thrown")
         } catch LocalAuthenticationError.noFingerprintEnrolled {
         } catch {
@@ -116,7 +116,7 @@ final class LocalAuthenticationProviderTests: XCTestCase {
         let context = MockLAContext(canEvaluatePolicyError: expectedError)
         let provider = LocalAuthenticationProvider(context: context)
         do {
-            _ = try await provider.checkBiometricAvailable()
+            _ = try await provider.checkBiometricAvailable(with: .biometrics)
             XCTFail("Error must be thrown")
         } catch LocalAuthenticationError.error(let error) {
             XCTAssertEqual(error as NSError, expectedError)


### PR DESCRIPTION
# Title

## Motivation

Add ability to specify local authentication policy while checking whether biometric authentication is available on the device

## Modifications

- Add enum containing available policies (LocalAuthenticationPolicy)
- Add param 'policy' to 'checkBiometricAvailable' function of LocalAuthenticationProviderProtocol
- Use 'checkBiometricAvailable' with appropriate policies

## Result

It is possible to set desired policy when checking biometric auth availability
