### PR TITLE
refactor: update LAError handling to include companionNotAvailable

### DIFF
--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationError.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationError.swift
@@ -91,6 +91,9 @@ public enum LocalAuthenticationError: Error {
     /// The user tapped the fallback button in the authentication dialog, but no fallback is available for the authentication policy.
     case userFallback
     
+    /// The authentication failed because the companion device (e.g., Apple Watch) is not available.
+    case companionNotAvailable
+    
     /// An underlying error occurred.
     ///
     /// - Parameter error: The underlying error.

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
@@ -199,9 +199,16 @@ public final class LocalAuthenticationProvider: LocalAuthenticationProviderProto
             logger.error("Biometric sensor data has invalid dimensions: \(localizedDescription)")
             return .invalidDimensions
 #endif
-        default:
+        case .companionNotAvailable:
+            logger.error("Companion device not available: \(localizedDescription)")
+            return .companionNotAvailable
+            
+        @unknown default:
             logger.error("Unknown LAError: \(localizedDescription)")
             return .error(laError)
+            // .touchIDLockout (depricated)
+            // .touchIDNotEnrolled (depricated)
+            // .touchIDNotAvailable (depricated)
         }
     }
     

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
@@ -199,10 +199,16 @@ public final class LocalAuthenticationProvider: LocalAuthenticationProviderProto
             logger.error("Biometric sensor data has invalid dimensions: \(localizedDescription)")
             return .invalidDimensions
 #endif
+#if compiler(>=6.0)
         case .companionNotAvailable:
-            logger.error("Companion device not available: \(localizedDescription)")
-            return .companionNotAvailable
-            
+            if #available(iOS 18.0, *) {
+                logger.error("Companion device not available: \(localizedDescription)")
+                return .companionNotAvailable
+            } else {
+                logger.error("Unknown LAError: \(localizedDescription)")
+                return .error(laError)
+            }
+#endif
         @unknown default:
             logger.error("Unknown LAError: \(localizedDescription)")
             return .error(laError)

--- a/Tests/LocalAuthenticationProviderTests/LocalAuthProviderLAErrorCasesTests.swift
+++ b/Tests/LocalAuthenticationProviderTests/LocalAuthProviderLAErrorCasesTests.swift
@@ -165,6 +165,22 @@ final class LocalAuthProviderLAErrorCasesTests: XCTestCase {
         } catch {
         }
     }
+    
+    @available(iOS 18.0, *)
+        func testMapToLocalAuthenticationErrorCompanionNotAvailable() async {
+            let context = MockLAContext(
+                canEvaluatePolicies: [.deviceOwnerAuthenticationWithBiometrics],
+                biometryType: .faceID,
+                evaluatePolicyError: LAError(.companionNotAvailable)
+            )
+            let provider = LocalAuthenticationProvider(context: context)
+            do {
+                _ = try await provider.authenticate(localizedReason: "Test")
+                XCTFail("Error must be thrown")
+            } catch LocalAuthenticationError.companionNotAvailable {
+            } catch {
+            }
+        }
 #if os(macOS)
     func testMapToLocalAuthenticationErrorBiometryDisconnected() async {
         let context = MockLAContext(

--- a/Tests/LocalAuthenticationProviderTests/LocalAuthProviderLAErrorCasesTests.swift
+++ b/Tests/LocalAuthenticationProviderTests/LocalAuthProviderLAErrorCasesTests.swift
@@ -165,7 +165,7 @@ final class LocalAuthProviderLAErrorCasesTests: XCTestCase {
         } catch {
         }
     }
-    
+#if compiler(>=6.0)
     @available(iOS 18.0, *)
         func testMapToLocalAuthenticationErrorCompanionNotAvailable() async {
             let context = MockLAContext(
@@ -181,6 +181,7 @@ final class LocalAuthProviderLAErrorCasesTests: XCTestCase {
             } catch {
             }
         }
+#endif
 #if os(macOS)
     func testMapToLocalAuthenticationErrorBiometryDisconnected() async {
         let context = MockLAContext(


### PR DESCRIPTION
# Title

## Motivation

*Update LAError handling to include case .companionNotAvailable.*

## Modifications

*Added case .companionNotAvailable, added test testMapToLocalAuthenticationErrorCompanionNotAvailable*

## Result

*Updated LAError handling cover all cases (without depricated: .touchIDLockout, .touchIDNotEnrolled, .touchIDNotAvailable) , including new companionNotAvailable.*
