### PR TITLE
feat: [DX-3212] extend provider API and  fixed deprecated LocalAuthentication policies on macOS

### DIFF
--- a/Sources/LocalAuthenticationProvider/LAContext+Extensions.swift
+++ b/Sources/LocalAuthenticationProvider/LAContext+Extensions.swift
@@ -10,20 +10,25 @@ import LocalAuthentication
 
 extension LAContext {
     internal func canEvaluate(policy: LocalAuthenticationPolicy, error: NSErrorPointer) -> Bool {
-        let localPolicy: LAPolicy
-        switch policy {
-        case .authentication:
-            localPolicy = .deviceOwnerAuthentication
-        case .biometrics:
-            localPolicy = .deviceOwnerAuthenticationWithBiometrics
-#if os(macOS)
-        case .watch:
-            localPolicy = .deviceOwnerAuthenticationWithWatch
-        case .biometricsOrWatch:
-            localPolicy = .deviceOwnerAuthenticationWithBiometricsOrWatch
-#endif
+        return self.canEvaluatePolicy(policy.laPolicy, error: error)
+    }
+    
+    /// Resolves the biometric type supported by the current context.
+    var resolvedBiometricType: BiometricType {
+        if biometryType == .none {
+            return .none
         }
-
-        return self.canEvaluatePolicy(localPolicy, error: error)
+        if biometryType == .faceID {
+            return .faceID
+        }
+        if biometryType == .touchID {
+            return .touchID
+        }
+        if #available(iOS 17.0, macOS 14.0, *) {
+            if biometryType == .opticID {
+                return .opticID
+            }
+        }
+        return .none
     }
 }

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationPolicy+Extensions.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationPolicy+Extensions.swift
@@ -1,0 +1,25 @@
+//
+//  LocalAuthenticationPolicy+Extensions.swift
+//
+//
+//  Created by Artem Panasenko on 19.01.2026.
+//
+
+import LocalAuthentication
+
+extension LocalAuthenticationPolicy {
+    var laPolicy: LAPolicy {
+        switch self {
+        case .authentication:
+            return .deviceOwnerAuthentication
+        case .biometrics:
+            return .deviceOwnerAuthenticationWithBiometrics
+#if os(macOS)
+        case .watch:
+            return .deviceOwnerAuthentication
+        case .biometricsOrWatch:
+            return .deviceOwnerAuthentication
+#endif
+        }
+    }
+}

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
@@ -76,7 +76,8 @@ public final class LocalAuthenticationProvider: LocalAuthenticationProviderProto
         _ = try await checkBiometricAvailable(with: .biometrics)
         do {
             return try await context.evaluatePolicy(
-                .deviceOwnerAuthenticationWithBiometrics, localizedReason: localizedReason
+                .deviceOwnerAuthentication,
+                localizedReason: localizedReason
             )
         } catch {
             throw mapToLocalAuthenticationError(error, context: context)
@@ -94,7 +95,7 @@ public final class LocalAuthenticationProvider: LocalAuthenticationProviderProto
             throw LocalAuthenticationError.biometricError
         }
         do {
-            if try await context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: localizedReason) {
+            if try await context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: localizedReason) {
                 return true
             }
         } catch {
@@ -106,7 +107,7 @@ public final class LocalAuthenticationProvider: LocalAuthenticationProviderProto
     /// Retrieves the type of biometric authentication available on the device.
     /// - Returns: The available biometric type (.none, .touchID, .faceID, or .opticID if available).
     public func getBiometricType() async -> BiometricType {
-        let result = context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+        let result = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
         logger.log("\(#function) evaluated policy with result \(result)")
         if context.biometryType == .none {
             return .none

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationProvider.swift
@@ -148,7 +148,6 @@ public final class LocalAuthenticationProvider: LocalAuthenticationProviderProto
         let result = context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
         logger.log("\(#function) evaluated policy with result \(result)")
         return context.resolvedBiometricType
-
     }
     
     /// Retrieves the type of  authentication for policy available on the device.

--- a/Sources/LocalAuthenticationProvider/LocalAuthenticationProviderProtocol.swift
+++ b/Sources/LocalAuthenticationProvider/LocalAuthenticationProviderProtocol.swift
@@ -40,6 +40,13 @@ public protocol LocalAuthenticationProviderProtocol {
     /// - Throws: An appropriate `LocalAuthenticationError` if an error occurs during setup.
     func setBiometricAuthentication(localizedReason: String) async throws -> Bool
     
+    /// Sets up authentication with biometry, Apple Watch, or the device passcode with the given localized reason, preparing for authentication but not initiating it immediately.
+    ///
+    /// - Parameter localizedReason: A string explaining why authentication is being requested.
+    /// - Returns: `true` if  authentication was successfully set up, `false` otherwise.
+    /// - Throws: An appropriate `LocalAuthenticationError` if an error occurs during setup.
+    func setOwnerAuthentication(localizedReason: String) async throws -> Bool
+
     /// Authenticates the user using biometric authentication with the given localized reason.
     ///
     /// - Parameter localizedReason: A string explaining why authentication is being requested.
@@ -47,8 +54,22 @@ public protocol LocalAuthenticationProviderProtocol {
     /// - Throws: An appropriate `LocalAuthenticationError` if an error occurs during authentication.
     func authenticate(localizedReason: String) async throws -> Bool
     
+    /// Authenticates the user using policy authentication with given localized reason.
+    ///
+    /// - Parameters:
+    ///   - police: `LocalAuthenticationPolicy`
+    ///   - localizedReason:  A string explaining why authentication is being requested.
+    /// - Returns: `true` if authentication was successful, `false` otherwise.
+    /// - Throws: An appropriate `LocalAuthenticationError` if an error occurs during authentication.
+    func authenticate(with police: LocalAuthenticationPolicy, localizedReason: String) async throws -> Bool
+    
     /// Retrieves the type of biometric authentication available on the device.
     ///
     /// - Returns: The available biometric type (.none, .touchID, .faceID, or .opticID if available).
     func getBiometricType() async -> BiometricType
+        
+    /// Retrieves the type of  authentication for policy available on the device.
+    ///
+    /// - Returns: The available biometric type (.none, .touchID, .faceID, or .opticID if available).
+    func getBiometricType(for policy: LocalAuthenticationPolicy) async -> BiometricType
 }

--- a/Tests/LocalAuthenticationProviderTests/LocalAuthProviderLAErrorCasesTests.swift
+++ b/Tests/LocalAuthenticationProviderTests/LocalAuthProviderLAErrorCasesTests.swift
@@ -165,7 +165,7 @@ final class LocalAuthProviderLAErrorCasesTests: XCTestCase {
         } catch {
         }
     }
-#if compiler(>=6.0)
+#if compiler(>=6.0) && os(iOS)
     @available(iOS 18.0, *)
         func testMapToLocalAuthenticationErrorCompanionNotAvailable() async {
             let context = MockLAContext(


### PR DESCRIPTION
# Title

Extend provider API and  fixed deprecated LocalAuthentication policies on macOS

## Motivation

The LocalAuthentication provider protocol was limited in flexibility:
it did not allow explicit owner authentication setup, policy-based authentication, or retrieving the biometric type in the context of a specific policy.

Additionally, the LocalAuthentication API on macOS contains deprecated policy combinations that can lead to warnings and unclear behavior when evaluating authentication capabilities.

## Modifications

1.  Extended LocalAuthenticationProviderProtocol.

2. Fixed deprecated LAPolicy usage on macOS.

The provider protocol was expanded to support additional authentication scenarios and clearer separation of responsibilities.

New methods added:

setOwnerAuthentication(localizedReason:)

authenticate(with:localizedReason:)

getBiometricType(for:)

## Result

- Deprecated LocalAuthentication policies are no longer used on macOS
- Authentication policy resolution is centralized and explicit
- The provider API is more complete, extensible, and future-proof
- Consumers can authenticate and query biometric capabilities based on specific policies
- Overall, this improves API clarity, platform correctness, and long-term maintainability.


